### PR TITLE
Include failing file information on upstream error

### DIFF
--- a/tasks/esperanto.js
+++ b/tasks/esperanto.js
@@ -33,6 +33,11 @@ module.exports = function(grunt) {
 				try {
 					return esperanto[method](code, options.bundleOpts).code;
 				} catch (err) {
+					// Direct throw config errors
+					if (err.name === 'EsperantoError') {
+						throw err;
+					}
+
 					// Rethrow with the file information
 					var toThrow = new Error('Error parsing ' + f.src + ': ' + (err.stack.split('\n')[0]));
 					toThrow.stack = 'Error parsing ' + f.src + ': ' + err.stack;

--- a/tasks/esperanto.js
+++ b/tasks/esperanto.js
@@ -28,11 +28,18 @@ module.exports = function(grunt) {
 			umd : 'toUmd'
 		}[String(options.type).toLowerCase()] || 'toAmd';
 
-		function transpile(code) {
-			return esperanto[method](code, options.bundleOpts).code;
-		}
-
 		this.files.forEach(function(f) {
+			function transpile(code) {
+				try {
+					return esperanto[method](code, options.bundleOpts).code;
+				} catch (err) {
+					// Rethrow with the file information
+					var toThrow = new Error('Error parsing ' + f.src + ': ' + (err.stack.split('\n')[0]));
+					toThrow.stack = 'Error parsing ' + f.src + ': ' + err.stack;
+					throw toThrow;
+				}
+			}
+
 			grunt.file.write(
 				f.dest,
 				f.src.filter(function(n, e) {


### PR DESCRIPTION
Before:

```
Running "esperanto:cjs" (esperanto) task
Warning: SyntaxError: Unexpected token (4:7) Use --force to continue.
```

After:

```
Running "esperanto:cjs" (esperanto) task
Warning: Error parsing lib/handlebars/compiler/base.js: SyntaxError: Unexpected token (4:7) Use --force to continue.
```
