### PR TITLE
Allow for using the file path as the name of the module when generating AMD modules.

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -56,6 +56,14 @@ module.exports = function(grunt) {
           'tmp/amd_with_name': ['test/fixtures/testing']
         }
       },
+      amd_with_file_path_name: {
+        options: {
+          filePathAsModule: true
+        },
+        files: {
+          'tmp/amd_with_file_path_name': ['test/fixtures/testing']
+        }
+      },
       umd: {
         options: {
           type: 'umd',

--- a/README.md
+++ b/README.md
@@ -64,6 +64,12 @@ Default value: `{}`
 
 Accept an esperanto [options](https://github.com/esperantojs/esperanto/wiki/Converting-a-single-module#options) parameter.
 
+#### options.filePathAsModule
+Type: `Boolean`
+Default value: `false`
+
+When outputting an amd module, if true will use the file path as the module name, stripping the `.js` suffix. This supercedes using `bundleOpts.amdName` which is a static equivalent.
+
 ### Usage Examples
 
 ```js

--- a/tasks/esperanto.js
+++ b/tasks/esperanto.js
@@ -19,7 +19,8 @@ module.exports = function(grunt) {
 			// defaults
 			type : 'amd',
 			separator : '\n',
-			bundleOpts: {}
+			bundleOpts: {},
+			filePathAsModule: false
 		});
 
 		method = {
@@ -31,7 +32,19 @@ module.exports = function(grunt) {
 		this.files.forEach(function(f) {
 			function transpile(code) {
 				try {
-					return esperanto[method](code, options.bundleOpts).code;
+					if (options.type === 'amd') {
+						if (options.filePathAsModule) {
+							var fileName = f.src[0];
+							var moduleName = fileName.replace(/\.js$/i, '');
+
+							options.bundleOpts.amdName = moduleName;
+							return esperanto[method](code, options.bundleOpts).code;
+						} else {
+							return esperanto[method](code, options.bundleOpts).code;
+						}
+					} else {
+						return esperanto[method](code, options.bundleOpts).code;
+					}
 				} catch (err) {
 					// Direct throw config errors
 					if (err.name === 'EsperantoError') {

--- a/test/esperanto_test.js
+++ b/test/esperanto_test.js
@@ -54,6 +54,15 @@ exports.esperanto = {
 
     test.done();
   },
+  amd_with_file_path_name: function(test) {
+    test.expect(1);
+
+    var actual = grunt.file.read('tmp/amd_with_file_path_name').replace(/\s|\n/g,'');
+    var expected = grunt.file.read('test/expected/amd_with_file_path_name').replace(/\s|\n/g,'');
+    test.equal(actual, expected, 'accept esperanto options using the file path as the amd name.');
+
+    test.done();
+  },
   umd: function(test) {
     test.expect(1);
 

--- a/test/expected/amd_with_file_path_name
+++ b/test/expected/amd_with_file_path_name
@@ -1,0 +1,10 @@
+define('test/fixtures/testing', ['lib'], function (name) {
+
+	'use strict';
+
+	name+'';
+
+
+	return 'foo';
+
+});


### PR DESCRIPTION
Addresses issue #6 
